### PR TITLE
Use sbt-conductr 2.0.1

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,5 @@
 addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.0.0-M1")
 // Needed for importing the project into Eclipse
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "3.0.0")
-
-addSbtPlugin("com.typesafe.sbt" % "sbt-lagom-bundle" % "1.0.3")
-
-addSbtPlugin("com.typesafe.conductr" % "sbt-conductr-sandbox" % "1.4.2")
+// The ConductR plugin
+addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.0.1")


### PR DESCRIPTION
Bumping the sbt-conductr version to 2.0.1. The new version includes the sandbox so it isn't necessary anymore to add the `sbt-conductr-sandbox` plugin additionally.